### PR TITLE
Fixed turn logic and enemy ai

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -1589,7 +1589,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &585606172
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3427,6 +3427,8 @@ MonoBehaviour:
   gameOver: 0
   pauseMenu: {fileID: 1148458908}
   gameOverMenu: {fileID: 1184291094}
+  playerStriker: {fileID: 82672645}
+  enemyStriker: {fileID: 585606171}
 --- !u!114 &1527715091
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -533,7 +533,6 @@ MonoBehaviour:
   StrikerSlider: {fileID: 676600230}
   strikerSpeed: 100
   strikerForceField: {fileID: 8536452892812301654}
-  pocket: {fileID: 4612410217761618161}
 --- !u!50 &82672649
 Rigidbody2D:
   serializedVersion: 4
@@ -1328,6 +1327,11 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &482534176 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6469751144476887390, guid: 72e13da6112dd2a4d940b8922e6eb1b0, type: 3}
+  m_PrefabInstance: {fileID: 226940821}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &506733546
 GameObject:
   m_ObjectHideFlags: 0
@@ -1566,6 +1570,141 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6988323450565643778, guid: f6a6fede6b139924898841b4c027d24c, type: 3}
   m_PrefabInstance: {fileID: 947142064}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &585606171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 585606176}
+  - component: {fileID: 585606175}
+  - component: {fileID: 585606174}
+  - component: {fileID: 585606173}
+  - component: {fileID: 585606172}
+  m_Layer: 0
+  m_Name: Enemy Striker
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &585606172
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585606171}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 40e28d750b320d146ae9d23ee698cee2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pocket: {fileID: 482534176}
+--- !u!50 &585606173
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585606171}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0.5
+  m_AngularDrag: 0.5
+  m_GravityScale: 0
+  m_Material: {fileID: 6200000, guid: cb6c6136b8d41944fb45765b51e4eb12, type: 2}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!58 &585606174
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585606171}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.011952986, y: 0}
+  serializedVersion: 2
+  m_Radius: 2.3111782
+--- !u!212 &585606175
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585606171}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 08edaf5397e488c4fba4bc71bf1e206e, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 5.22, y: 5.22}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &585606176
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 585606171}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 3.35, z: 0}
+  m_LocalScale: {x: 0.14535661, y: 0.14535661, z: 0.14535661}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &656167741
 GameObject:
   m_ObjectHideFlags: 0
@@ -4709,11 +4848,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7be4cff81cb06424ca45fb6c766ab3df, type: 3}
---- !u!1 &4612410217761618161 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6469751144476887390, guid: 72e13da6112dd2a4d940b8922e6eb1b0, type: 3}
-  m_PrefabInstance: {fileID: 1858789024331264431}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6711160891172082894
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/EnemyStrikerController.cs
+++ b/Assets/Scripts/EnemyStrikerController.cs
@@ -1,0 +1,83 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemyStrikerController : MonoBehaviour
+{
+    [SerializeField]
+    GameObject pocket;
+
+    Rigidbody2D rb;
+    
+    bool again = false;
+
+    private void OnEnable()
+    {
+        transform.position = new Vector3(0, 3.54f, 0);
+        StartCoroutine(EnemyTurn()); 
+    }
+
+    private void Awake()
+    {
+        rb = GetComponent<Rigidbody2D>();
+        
+    }
+
+    private void Update() {
+        enabled = !StrikerController.playerTurn;
+        Debug.Log(StrikerController.playerTurn);
+    }
+
+
+    IEnumerator EnemyTurn()
+    {
+        // Determine which coin to hit based on game logic.
+        // For example, the AI could target the closest coin to the pocket, or a high-value coin.
+        yield return new WaitForSeconds(2f);
+
+        GameObject[] coins = GameObject.FindGameObjectsWithTag("Black");
+        GameObject closestCoin = null;
+        float closestDistance = Mathf.Infinity;
+        if (coins.Length == 0)
+        {
+            Debug.Log("No coins left");
+            yield break;
+        }
+
+        foreach (GameObject coin in coins)
+        {
+            float distance = Vector3.Distance(coin.transform.position, pocket.transform.position);
+            if (distance < closestDistance)
+            {
+                closestCoin = coin;
+                closestDistance = distance;
+            }
+        }
+
+        // Calculate the direction and speed of the striker based on the position of the target coin and the enemy's striker.
+
+        Vector3 targetDirection = closestCoin.transform.position - transform.position;
+        targetDirection.z = 0f;
+        float targetSpeed = CalculateStrikerSpeed(targetDirection.magnitude);
+
+        // Apply the calculated force to the striker and end the enemy's turn.
+
+        
+        rb.AddForce(targetDirection.normalized * targetSpeed, ForceMode2D.Impulse);
+
+        yield return new WaitUntil(() => rb.velocity.magnitude < 0.1f);
+
+    }
+
+    float CalculateStrikerSpeed(float distance)
+    {
+        float maxDistance = 2.0f; // Maximum distance the striker can travel
+        float minSpeed = 10f; // Minimum striker speed
+        float maxSpeed = 40f; // Maximum striker speed
+
+        float speed = Mathf.Lerp(minSpeed, maxSpeed, distance / maxDistance);
+        return speed;
+    }
+
+
+}

--- a/Assets/Scripts/EnemyStrikerController.cs
+++ b/Assets/Scripts/EnemyStrikerController.cs
@@ -7,33 +7,35 @@ public class EnemyStrikerController : MonoBehaviour
     [SerializeField]
     GameObject pocket;
 
+
     Rigidbody2D rb;
-    
-    bool again = false;
+    bool isMoving;
 
-    private void OnEnable()
+    private void Start()
     {
-        transform.position = new Vector3(0, 3.54f, 0);
-        StartCoroutine(EnemyTurn()); 
-    }
-
-    private void Awake()
-    {
+        isMoving = false;
         rb = GetComponent<Rigidbody2D>();
         
     }
 
+
     private void Update() {
-        enabled = !StrikerController.playerTurn;
-        Debug.Log(StrikerController.playerTurn);
+        if (rb.velocity.magnitude < 0.1f && !isMoving)
+        {
+            isMoving = true;
+            StartCoroutine(EnemyTurn());
+        }
     }
+
 
 
     IEnumerator EnemyTurn()
     {
         // Determine which coin to hit based on game logic.
         // For example, the AI could target the closest coin to the pocket, or a high-value coin.
+        transform.position = new Vector3(0f, 3.45f, 0f);
         yield return new WaitForSeconds(2f);
+        
 
         GameObject[] coins = GameObject.FindGameObjectsWithTag("Black");
         GameObject closestCoin = null;
@@ -64,9 +66,9 @@ public class EnemyStrikerController : MonoBehaviour
 
         
         rb.AddForce(targetDirection.normalized * targetSpeed, ForceMode2D.Impulse);
-
         yield return new WaitUntil(() => rb.velocity.magnitude < 0.1f);
-
+        isMoving = false;
+        
     }
 
     float CalculateStrikerSpeed(float distance)

--- a/Assets/Scripts/EnemyStrikerController.cs
+++ b/Assets/Scripts/EnemyStrikerController.cs
@@ -6,8 +6,6 @@ public class EnemyStrikerController : MonoBehaviour
 {
     [SerializeField]
     GameObject pocket;
-
-
     Rigidbody2D rb;
     bool isMoving;
 
@@ -24,6 +22,7 @@ public class EnemyStrikerController : MonoBehaviour
         {
             isMoving = true;
             StartCoroutine(EnemyTurn());
+            StrikerController.playerTurn = true;
         }
     }
 
@@ -68,6 +67,7 @@ public class EnemyStrikerController : MonoBehaviour
         rb.AddForce(targetDirection.normalized * targetSpeed, ForceMode2D.Impulse);
         yield return new WaitUntil(() => rb.velocity.magnitude < 0.1f);
         isMoving = false;
+        
         
     }
 

--- a/Assets/Scripts/EnemyStrikerController.cs
+++ b/Assets/Scripts/EnemyStrikerController.cs
@@ -22,7 +22,6 @@ public class EnemyStrikerController : MonoBehaviour
         {
             isMoving = true;
             StartCoroutine(EnemyTurn());
-            StrikerController.playerTurn = true;
         }
     }
 
@@ -67,7 +66,7 @@ public class EnemyStrikerController : MonoBehaviour
         rb.AddForce(targetDirection.normalized * targetSpeed, ForceMode2D.Impulse);
         yield return new WaitUntil(() => rb.velocity.magnitude < 0.1f);
         isMoving = false;
-        
+        StrikerController.playerTurn = true;
         
     }
 

--- a/Assets/Scripts/EnemyStrikerController.cs
+++ b/Assets/Scripts/EnemyStrikerController.cs
@@ -64,6 +64,8 @@ public class EnemyStrikerController : MonoBehaviour
 
         
         rb.AddForce(targetDirection.normalized * targetSpeed, ForceMode2D.Impulse);
+
+        yield return new WaitForSeconds(0.1f);
         yield return new WaitUntil(() => rb.velocity.magnitude < 0.1f);
         isMoving = false;
         StrikerController.playerTurn = true;

--- a/Assets/Scripts/EnemyStrikerController.cs.meta
+++ b/Assets/Scripts/EnemyStrikerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40e28d750b320d146ae9d23ee698cee2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -63,11 +63,11 @@ public class GameManager : MonoBehaviour
 
         
             if(StrikerController.playerTurn == true ){
-                playerStriker.GetComponent<StrikerController>().enabled = true;
-                enemyStriker.GetComponent<EnemyStrikerController>().enabled = false;
+                playerStriker.SetActive(true);
+                enemyStriker.SetActive(false); 
             }else{
-                playerStriker.GetComponent<StrikerController>().enabled = false;
-                enemyStriker.GetComponent<EnemyStrikerController>().enabled = true;
+                playerStriker.SetActive(false);
+                enemyStriker.SetActive(true);
             }
         
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -23,6 +23,15 @@ public class GameManager : MonoBehaviour
     [SerializeField]
     GameObject gameOverMenu;
 
+
+    [SerializeField]
+    GameObject playerStriker;
+
+    [SerializeField]
+    GameObject enemyStriker;
+
+
+
     
 
     void Start()
@@ -51,6 +60,17 @@ public class GameManager : MonoBehaviour
     }
 
     void Update(){
+
+        
+            if(StrikerController.playerTurn == true ){
+                playerStriker.GetComponent<StrikerController>().enabled = true;
+                enemyStriker.GetComponent<EnemyStrikerController>().enabled = false;
+            }else{
+                playerStriker.GetComponent<StrikerController>().enabled = false;
+                enemyStriker.GetComponent<EnemyStrikerController>().enabled = true;
+            }
+        
+
 
         if(timerScript.isTimerRunning == false || BoardScript.scorePlayer1 == 5 || BoardScript.scorePlayer2 == 5){
             onGameOver();

--- a/Assets/Scripts/StrikerController.cs
+++ b/Assets/Scripts/StrikerController.cs
@@ -18,10 +18,13 @@ public class StrikerController : MonoBehaviour
     bool isCharging;
     Vector2 direction;
     Rigidbody2D rb;
-    public static bool playerTurn = true;
+    public static bool playerTurn;
+    bool isMoving;
 
     private void Start()
     {
+        playerTurn = true;
+        isMoving = false;
         rb = GetComponent<Rigidbody2D>();
     }
 
@@ -37,20 +40,27 @@ public class StrikerController : MonoBehaviour
         strikerForceField.gameObject.SetActive(true);
     }
 
-    private void OnMouseUp()
+    private IEnumerator OnMouseUp()
     {
+        yield return new WaitForSeconds(0.1f);
         if (!isCharging)
         {
-            return;
+            yield break;
         }
+
 
         strikerForceField.gameObject.SetActive(false);
         isCharging = false;
         Vector3 direction = transform.position - Camera.main.ScreenToWorldPoint(Input.mousePosition);
         direction.z = 0f;
         rb.AddForce(direction * strikerSpeed);
-        
+
+        yield return new WaitUntil(() => rb.velocity.magnitude < 0.1f);
+        isMoving = false;
+
     }
+
+
 
     private void OnMouseDrag()
     {
@@ -70,23 +80,29 @@ public class StrikerController : MonoBehaviour
 
     private void Update()
     {
+        if (rb.velocity.magnitude < 0.1f && !isMoving)
+        {
+            isMoving = true;
+            StartCoroutine(OnMouseUp());
+            
+            playerTurn = false;
+        }
+
         if (rb.velocity.magnitude > 0.1f)
         {
             StrikerSlider.gameObject.SetActive(false);
         }
 
-        if (!isCharging && rb.velocity.magnitude < 0.1f && playerTurn == true)
+        if (!isCharging && rb.velocity.magnitude < 0.1f)
         {
             StrikerXPos();
         }
 
     }
 
-
     public void StrikerXPos()
     {
         Debug.Log("StrikerXPos");
-        playerTurn = false;
         StrikerSlider.gameObject.SetActive(true);
         transform.position = new Vector3(StrikerSlider.value, -4.57f, 0);
     }

--- a/Assets/Scripts/StrikerController.cs
+++ b/Assets/Scripts/StrikerController.cs
@@ -18,7 +18,7 @@ public class StrikerController : MonoBehaviour
     bool isCharging;
     Vector2 direction;
     Rigidbody2D rb;
-    public static bool playerTurn;
+    public static bool playerTurn ;
     bool isMoving;
 
     private void Start()
@@ -42,12 +42,13 @@ public class StrikerController : MonoBehaviour
 
     private IEnumerator OnMouseUp()
     {
+        isMoving = true;
         yield return new WaitForSeconds(0.1f);
         if (!isCharging)
         {
             yield break;
         }
-
+        
 
         strikerForceField.gameObject.SetActive(false);
         isCharging = false;
@@ -57,7 +58,7 @@ public class StrikerController : MonoBehaviour
 
         yield return new WaitUntil(() => rb.velocity.magnitude < 0.1f);
         isMoving = false;
-
+        playerTurn = false;
     }
 
 
@@ -84,8 +85,6 @@ public class StrikerController : MonoBehaviour
         {
             isMoving = true;
             StartCoroutine(OnMouseUp());
-            
-            playerTurn = false;
         }
 
         if (rb.velocity.magnitude > 0.1f)
@@ -102,7 +101,6 @@ public class StrikerController : MonoBehaviour
 
     public void StrikerXPos()
     {
-        Debug.Log("StrikerXPos");
         StrikerSlider.gameObject.SetActive(true);
         transform.position = new Vector3(StrikerSlider.value, -4.57f, 0);
     }

--- a/Assets/Scripts/StrikerController.cs
+++ b/Assets/Scripts/StrikerController.cs
@@ -56,6 +56,7 @@ public class StrikerController : MonoBehaviour
         direction.z = 0f;
         rb.AddForce(direction * strikerSpeed);
 
+        yield return new WaitForSeconds(0.1f);
         yield return new WaitUntil(() => rb.velocity.magnitude < 0.1f);
         isMoving = false;
         playerTurn = false;

--- a/Assets/Scripts/StrikerController.cs
+++ b/Assets/Scripts/StrikerController.cs
@@ -15,8 +15,6 @@ public class StrikerController : MonoBehaviour
     [SerializeField]
     Transform strikerForceField;
 
-    [SerializeField]
-    GameObject pocket;
     bool isCharging;
     Vector2 direction;
     Rigidbody2D rb;
@@ -51,7 +49,7 @@ public class StrikerController : MonoBehaviour
         Vector3 direction = transform.position - Camera.main.ScreenToWorldPoint(Input.mousePosition);
         direction.z = 0f;
         rb.AddForce(direction * strikerSpeed);
-        playerTurn = false;
+        
     }
 
     private void OnMouseDrag()
@@ -70,91 +68,27 @@ public class StrikerController : MonoBehaviour
         strikerForceField.localScale = new Vector3(scaleValue, scaleValue, scaleValue);
     }
 
-    private void LateUpdate()
+    private void Update()
     {
         if (rb.velocity.magnitude > 0.1f)
         {
             StrikerSlider.gameObject.SetActive(false);
         }
 
-
-        if (!isCharging)
+        if (!isCharging && rb.velocity.magnitude < 0.1f && playerTurn == true)
         {
-            StartCoroutine(StrikerXPos());
+            StrikerXPos();
         }
 
     }
 
-    IEnumerator EnemyTurn()
+
+    public void StrikerXPos()
     {
-        // Determine which coin to hit based on game logic.
-        // For example, the AI could target the closest coin to the pocket, or a high-value coin.
-
-        GameObject[] coins = GameObject.FindGameObjectsWithTag("Black");
-        GameObject closestCoin = null;
-        float closestDistance = Mathf.Infinity;
-        if (coins.Length == 0)
-        {
-            Debug.Log("No coins left");
-            yield break;
-        }
-
-        foreach (GameObject coin in coins)
-        {
-            float distance = Vector3.Distance(coin.transform.position, pocket.transform.position);
-            if (distance < closestDistance)
-            {
-                closestCoin = coin;
-                closestDistance = distance;
-            }
-        }
-
-        // Calculate the direction and speed of the striker based on the position of the target coin and the enemy's striker.
-
-        Vector3 targetDirection = closestCoin.transform.position - transform.position;
-        targetDirection.z = 0f;
-        float targetSpeed = CalculateStrikerSpeed(targetDirection.magnitude);
-
-        // Apply the calculated force to the striker and end the enemy's turn.
-
-        rb.AddForce(targetDirection.normalized * targetSpeed);
-        
-        yield return new WaitForSeconds(0.1f);
-        yield return new WaitUntil(() => rb.velocity.magnitude < 0.1f);
-        rb.velocity = Vector2.zero;
-        rb.rotation = 0f;
-
-        playerTurn = true;
-    }
-
-    float CalculateStrikerSpeed(float distance)
-    {
-        float maxDistance = 2.0f; // Maximum distance the striker can travel
-        float minSpeed = 10f; // Minimum striker speed
-        float maxSpeed = 70f; // Maximum striker speed
-
-        float speed = Mathf.Lerp(minSpeed, maxSpeed, distance / maxDistance);
-        return speed;
-    }
-
-
-    public IEnumerator StrikerXPos()
-    {
-        yield return new WaitForSeconds(0.1f);
-        yield return new WaitUntil(() => rb.velocity.magnitude < 0.1f);
-        rb.velocity = Vector2.zero;
-        rb.rotation = 0f;
-        
-        if (playerTurn)
-        {
-            StrikerSlider.gameObject.SetActive(true);
-            transform.position = new Vector3(StrikerSlider.value, -4.57f, 0);
-        }
-        else
-        {
-            transform.position = new Vector3(0, 3.45f, 0);
-            StartCoroutine(EnemyTurn());
-        }
+        Debug.Log("StrikerXPos");
+        playerTurn = false;
+        StrikerSlider.gameObject.SetActive(true);
+        transform.position = new Vector3(StrikerSlider.value, -4.57f, 0);
     }
 
 }


### PR DESCRIPTION
The game would bug out randomly and skip turns. 

Fix:
- Added independent scripts for both the strikers(enemy ai and player).
- Added check in GameManager to see which striker will be spawned.
- Fixed coroutines to switch turns when the stricker's velocity < 0.1f
 